### PR TITLE
update Run required_action

### DIFF
--- a/src/v1/api.rs
+++ b/src/v1/api.rs
@@ -16,7 +16,7 @@ use super::resources::shared::ResponseWrapper;
 
 const OPENAI_API_V1_ENDPOINT: &str = "https://api.openai.com/v1";
 
-#[derive(Clone,Default,Debug)]
+#[derive(Clone, Debug)]
 pub struct Client {
     pub http_client: reqwest::Client,
     pub base_url: String,

--- a/src/v1/api.rs
+++ b/src/v1/api.rs
@@ -16,6 +16,7 @@ use super::resources::shared::ResponseWrapper;
 
 const OPENAI_API_V1_ENDPOINT: &str = "https://api.openai.com/v1";
 
+#[derive(Clone,Default,Debug)]
 pub struct Client {
     pub http_client: reqwest::Client,
     pub base_url: String,

--- a/src/v1/resources/assistant/run.rs
+++ b/src/v1/resources/assistant/run.rs
@@ -20,7 +20,7 @@ pub struct Run {
     pub status: RunStatus,
     /// Details on the action required to continue the run. Will be null if no action is required.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub action: Option<RunAction>,
+    pub required_action: Option<RunAction>,
     /// The last error associated with this run. Will be null if there are no errors.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub last_error: Option<RunError>,
@@ -57,7 +57,7 @@ pub struct RunAction {
     /// For now, this is always 'submit_tool_outputs'.
     pub r#type: String,
     /// Details on the tool outputs needed for this run to continue.
-    pub submit_tool_outputs: Vec<RunActionSubmitToolOutput>,
+    pub submit_tool_outputs: RunActionSubmitToolOutput,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]


### PR DESCRIPTION
run action changes in accordance with current openai API
```
required_action
object or null

Details on the action required to continue the run. Will be null if no action is required.
type
string

For now, this is always submit_tool_outputs.
submit_tool_outputs
object

Details on the tool outputs needed for this run to continue.
tool_calls
array

A list of the relevant tool calls.
id
string

The ID of the tool call. This ID must be referenced when you submit the tool outputs in using the [Submit tool outputs to run](https://platform.openai.com/docs/api-reference/runs/submitToolOutputs) endpoint.
type
string

The type of tool call the output is required for. For now, this is always function.
function
object

The function definition.
```
