### PR TITLE
Fix building without reqwest

### DIFF
--- a/.github/workflows/cargo-build.yml
+++ b/.github/workflows/cargo-build.yml
@@ -18,3 +18,12 @@ jobs:
     - uses: actions/checkout@v3
     - name: Build
       run: cargo build --verbose
+
+  build-without-reqwest:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build
+      run: cargo build --verbose --no-default-features

--- a/src/v1/resources/shared.rs
+++ b/src/v1/resources/shared.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "reqwest")]
 use reqwest::header::HeaderMap;
 use serde::{Deserialize, Serialize};
 
@@ -101,6 +102,7 @@ pub enum StopToken {
     Array(Vec<String>),
 }
 
+#[cfg(feature = "reqwest")]
 impl From<HeaderMap> for Headers {
     fn from(value: HeaderMap) -> Self {
         if value.get("x-ratelimit-limit-requests").is_none()


### PR DESCRIPTION
This fixes a compilation error when building with `no-default-features`, and adds a build step to compile without default-features to make sure it keeps working.