### PR TITLE
Drop v1::endpoints::chat::StreamChatCompletionParameters

### DIFF
--- a/examples/chat/create_chat_completion_stream/src/main.rs
+++ b/examples/chat/create_chat_completion_stream/src/main.rs
@@ -27,7 +27,6 @@ async fn main() {
             },
         ],
         max_tokens: Some(12),
-        stream: Some(true),
         ..Default::default()
     };
 

--- a/examples/chat/create_chat_completion_stream/src/main.rs
+++ b/examples/chat/create_chat_completion_stream/src/main.rs
@@ -27,6 +27,7 @@ async fn main() {
             },
         ],
         max_tokens: Some(12),
+        stream: Some(true),
         ..Default::default()
     };
 

--- a/src/v1/endpoints/chat.rs
+++ b/src/v1/endpoints/chat.rs
@@ -55,25 +55,8 @@ impl Chat<'_> {
         Pin<Box<dyn Stream<Item = Result<ChatCompletionChunkResponse, APIError>> + Send>>,
         APIError,
     > {
-        use crate::v1::resources::chat::StreamChatCompletionParameters;
-
-        let stream_parameters = StreamChatCompletionParameters {
-            messages: parameters.messages,
-            model: parameters.model,
-            frequency_penalty: parameters.frequency_penalty,
-            logit_bias: parameters.logit_bias,
-            max_tokens: parameters.max_tokens,
-            n: parameters.n,
-            presence_penalty: parameters.presence_penalty,
-            response_format: parameters.response_format,
-            stop: parameters.stop,
-            stream: true,
-            temperature: parameters.temperature,
-            top_p: parameters.top_p,
-            tools: parameters.tools,
-            tool_choice: parameters.tool_choice,
-            user: parameters.user,
-        };
+        let mut stream_parameters = parameters;
+        stream_parameters.stream = Some(true);
 
         Ok(self
             .client

--- a/src/v1/resources/chat.rs
+++ b/src/v1/resources/chat.rs
@@ -88,6 +88,10 @@ pub struct ChatCompletionParameters {
     /// Up to 4 sequences where the API will stop generating further tokens.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stop: Option<StopToken>,
+    /// If set, partial messages will be sent, like in ChatGPT. Tokens will be sent as data-only server-sent events
+    /// as they become available, with the stream terminated by a data: [DONE] message.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stream: Option<bool>,
     /// What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random,
     /// while lower values like 0.2 will make it more focused and deterministic.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -252,38 +256,6 @@ pub struct ChatCompletionChunkChoice {
     pub finish_reason: Option<FinishReason>,
 }
 
-#[cfg(feature = "stream")]
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-pub struct StreamChatCompletionParameters {
-    pub messages: Vec<ChatMessage>,
-    pub model: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub frequency_penalty: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub logit_bias: Option<HashMap<String, i32>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub max_tokens: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub n: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub presence_penalty: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub response_format: Option<ChatCompletionResponseFormat>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub stop: Option<StopToken>,
-    pub stream: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub temperature: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub top_p: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub tools: Option<Vec<ChatCompletionTool>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub tool_choice: Option<ChatCompletionToolChoice>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub user: Option<String>,
-}
-
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct ImageUrl {
     /// The type of the content part.
@@ -374,6 +346,7 @@ impl Default for ChatCompletionParameters {
             response_format: None,
             seed: None,
             stop: None,
+            stream: None,
             temperature: None,
             top_p: None,
             tools: None,


### PR DESCRIPTION
Drop v1::endpoints::chat::StreamChatCompletionParameters in favor of using ChatCompletionParameters with an added optional stream field. This allows using the struct for server-side processing of OpenAI API requests.

The StreamChatCompletionParameters lacks a few fields (logprobs, seed, and lacks code documentation compared to ChatCompletionParameters. Aside from that, removing StreamChatCompletionParameters reduces code maintenance overhead.