### PR TITLE
resources/shared: always rename FinishReason fields

### DIFF
--- a/src/v1/resources/shared.rs
+++ b/src/v1/resources/shared.rs
@@ -82,16 +82,16 @@ pub struct DeletedObject {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub enum FinishReason {
     /// API returned complete message, or a message terminated by one of the stop sequences provided via the stop parameter.
-    #[serde(rename(deserialize = "stop"))]
+    #[serde(rename = "stop")]
     StopSequenceReached,
     /// Incomplete model output due to max_tokens parameter or token limit.
-    #[serde(rename(deserialize = "length"))]
+    #[serde(rename = "length")]
     TokenLimitReached,
     /// Omitted content due to a flag from our content filters.
-    #[serde(rename(deserialize = "content_filter"))]
+    #[serde(rename = "content_filter")]
     ContentFilterFlagged,
     /// The model decided to call one or more tools.
-    #[serde(rename(deserialize = "tool_calls"))]
+    #[serde(rename = "tool_calls")]
     ToolCalls,
 }
 


### PR DESCRIPTION
This way the struct can be properly used to create a response to an OpenAI API client.