### PR TITLE
pagination tokens are null when list is empty for messages

### DIFF
--- a/src/v1/resources/assistant/message.rs
+++ b/src/v1/resources/assistant/message.rs
@@ -131,9 +131,9 @@ pub struct ListMessagesResponse {
     /// The list of assistant files.
     pub data: Vec<Message>,
     /// ID of the first object in the list.
-    pub first_id: String,
+    pub first_id: Option<String>,
     /// ID of the last object in the list.
-    pub last_id: String,
+    pub last_id: Option<String>,
     /// Indicates whether there are more assistant files to retrieve.
     pub has_more: bool,
 }


### PR DESCRIPTION
Messages are optional when creating a thread. See here: https://platform.openai.com/docs/api-reference/threads/createThread

When that happens the `first_id` and `last_id` are `null` in the response when listing messages for that thread.
This may be the case for more list type responses but its unclear from the docs.