### PR TITLE
error: enable serialize for APIError

### DIFF
--- a/src/v1/error.rs
+++ b/src/v1/error.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter, Result};
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub enum APIError {
     EndpointError(String),
     InvalidRequestError(String),


### PR DESCRIPTION
This way the struct can be used to create an error response to an OpenAI API client.