### PR TITLE
Add AudioTranscriptionFile enum

### DIFF
--- a/examples/audio/create_transcription/src/main.rs
+++ b/examples/audio/create_transcription/src/main.rs
@@ -1,5 +1,5 @@
 use openai_dive::v1::api::Client;
-use openai_dive::v1::resources::audio::{AudioOutputFormat, AudioTranscriptionParameters};
+use openai_dive::v1::resources::audio::{AudioOutputFormat, AudioTranscriptionFile, AudioTranscriptionParameters};
 use std::env;
 
 #[tokio::main]
@@ -9,7 +9,7 @@ async fn main() {
     let client = Client::new(api_key);
 
     let parameters = AudioTranscriptionParameters {
-        file: "./audio/micro-machines.mp3".to_string(),
+        file: AudioTranscriptionFile::File("./audio/micro-machines.mp3".to_string()),
         model: "whisper-1".to_string(),
         language: None,
         prompt: None,

--- a/src/v1/endpoints/audio.rs
+++ b/src/v1/endpoints/audio.rs
@@ -1,6 +1,6 @@
 use crate::v1::api::Client;
 use crate::v1::error::APIError;
-use crate::v1::helpers::file_from_disk_to_form_part;
+use crate::v1::helpers::{file_from_bytes_to_form_part, file_from_disk_to_form_part};
 use crate::v1::resources::audio::AudioSpeechParameters;
 use crate::v1::resources::audio::AudioSpeechResponse;
 #[cfg(feature = "stream")]
@@ -45,6 +45,7 @@ impl Audio<'_> {
         let mut form = reqwest::multipart::Form::new();
 
         let file = match parameters.file {
+            AudioTranscriptionFile::Bytes(b) => file_from_bytes_to_form_part(b)?,
             AudioTranscriptionFile::File(f) => file_from_disk_to_form_part(f).await?,
         };
 

--- a/src/v1/endpoints/audio.rs
+++ b/src/v1/endpoints/audio.rs
@@ -5,7 +5,9 @@ use crate::v1::resources::audio::AudioSpeechParameters;
 use crate::v1::resources::audio::AudioSpeechResponse;
 #[cfg(feature = "stream")]
 use crate::v1::resources::audio::AudioSpeechResponseChunkResponse;
-use crate::v1::resources::audio::{AudioTranscriptionParameters, AudioTranslationParameters};
+use crate::v1::resources::audio::{
+    AudioTranscriptionFile, AudioTranscriptionParameters, AudioTranslationParameters,
+};
 #[cfg(feature = "stream")]
 use futures::Stream;
 #[cfg(feature = "stream")]
@@ -42,7 +44,10 @@ impl Audio<'_> {
     ) -> Result<String, APIError> {
         let mut form = reqwest::multipart::Form::new();
 
-        let file = file_from_disk_to_form_part(parameters.file).await?;
+        let file = match parameters.file {
+            AudioTranscriptionFile::File(f) => file_from_disk_to_form_part(f).await?,
+        };
+
         form = form.part("file", file);
 
         form = form.text("model", parameters.model);

--- a/src/v1/helpers.rs
+++ b/src/v1/helpers.rs
@@ -1,4 +1,5 @@
 use crate::v1::error::APIError;
+use crate::v1::resources::audio::AudioTranscriptionBytes;
 #[cfg(feature = "download")]
 use rand::{distributions::Alphanumeric, Rng};
 use reqwest::multipart::Part;
@@ -28,6 +29,13 @@ pub fn format_response<R: DeserializeOwned>(response: String) -> Result<R, APIEr
 
 pub fn is_beta_feature(path: &str) -> bool {
     path.starts_with("/assistants") || path.starts_with("/threads")
+}
+
+pub fn file_from_bytes_to_form_part(input: AudioTranscriptionBytes) -> Result<Part, APIError> {
+    reqwest::multipart::Part::bytes(input.bytes.to_vec())
+        .file_name(input.filename)
+        .mime_str("application/octet-stream")
+        .map_err(|error| APIError::FileError(error.to_string()))
 }
 
 pub async fn file_from_disk_to_form_part(path: String) -> Result<Part, APIError> {

--- a/src/v1/resources/audio.rs
+++ b/src/v1/resources/audio.rs
@@ -22,6 +22,7 @@ pub struct AudioSpeechParameters {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct AudioTranscriptionParameters {
     /// The audio file object (not file name) to transcribe, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
+    #[serde(skip)]
     pub file: AudioTranscriptionFile,
     /// ID of the model to use. Only whisper-1 is currently available.
     pub model: String,
@@ -115,8 +116,15 @@ pub enum AudioSpeechResponseFormat {
     Pcm,
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, PartialEq)]
+pub struct AudioTranscriptionBytes {
+    pub bytes: Bytes,
+    pub filename: String,
+}
+
+#[derive(Clone, Debug, PartialEq)]
 pub enum AudioTranscriptionFile {
+    Bytes(AudioTranscriptionBytes),
     File(String),
 }
 
@@ -176,5 +184,11 @@ impl AudioSpeechResponse {
             .map_err(|error| APIError::FileError(error.to_string()))?;
 
         Ok(())
+    }
+}
+
+impl Default for AudioTranscriptionFile {
+    fn default() -> Self {
+        Self::File(String::new())
     }
 }

--- a/src/v1/resources/audio.rs
+++ b/src/v1/resources/audio.rs
@@ -22,7 +22,7 @@ pub struct AudioSpeechParameters {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct AudioTranscriptionParameters {
     /// The audio file object (not file name) to transcribe, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
-    pub file: String,
+    pub file: AudioTranscriptionFile,
     /// ID of the model to use. Only whisper-1 is currently available.
     pub model: String,
     /// The language of the input audio. Supplying the input language in ISO-639-1 format will improve accuracy and latency.
@@ -113,6 +113,11 @@ pub enum AudioSpeechResponseFormat {
     Flac,
     Wav,
     Pcm,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub enum AudioTranscriptionFile {
+    File(String),
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]


### PR DESCRIPTION
This PR makes it possible to pass the audio file content as bytes,
making the library more flexible. E.g. it now becomes possible to get
the audio file via a network connection and pass it directly without
having to use a temporary file.