### PR TITLE
tree-wide: use serde rename_all snake_case

### DIFF
--- a/src/v1/resources/assistant/run.rs
+++ b/src/v1/resources/assistant/run.rs
@@ -122,12 +122,10 @@ pub struct ListRunsResponse {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "snake_case")]
 pub enum RunStatus {
     Queued,
-    #[serde(rename = "in_progress")]
     InProgress,
-    #[serde(rename = "requires_action")]
     RequiresAction,
     Cancelling,
     Cancelled,
@@ -137,10 +135,9 @@ pub enum RunStatus {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "snake_case")]
 pub enum RunErrorCode {
-    #[serde(rename = "server_error")]
     ServerError,
-    #[serde(rename = "rate_limit_exceeded")]
     RateLimitExceeded,
 }
 

--- a/src/v1/resources/audio.rs
+++ b/src/v1/resources/audio.rs
@@ -95,12 +95,11 @@ pub struct AudioSpeechResponseChunkResponse {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "snake_case")]
 pub enum AudioOutputFormat {
     Json,
     Text,
     Srt,
-    #[serde(rename = "verbose_json")]
     VerboseJson,
     Vtt,
 }

--- a/src/v1/resources/chat.rs
+++ b/src/v1/resources/chat.rs
@@ -295,10 +295,9 @@ pub enum ChatMessageContent {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "snake_case")]
 pub enum ChatCompletionResponseFormatType {
-    #[serde(rename = "text")]
     Text,
-    #[serde(rename = "json_object")]
     JsonObject,
 }
 

--- a/src/v1/resources/file.rs
+++ b/src/v1/resources/file.rs
@@ -42,14 +42,13 @@ pub struct UploadFileParameters {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "snake_case")]
 pub enum FilePurpose {
     #[serde(rename = "fine-tune")]
     FineTune,
     #[serde(rename = "fine-tune-results")]
     FineTuneResults,
-    #[serde(rename = "assistants")]
     Assistants,
-    #[serde(rename = "assistants_output")]
     AssistantsOutput,
 }
 

--- a/src/v1/resources/fine_tuning.rs
+++ b/src/v1/resources/fine_tuning.rs
@@ -143,9 +143,8 @@ pub enum NEpochs {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "snake_case")]
 pub enum FineTuningJobStatus {
-    #[serde(rename = "validating_files")]
     ValidatingFiles,
     Queued,
     Running,

--- a/src/v1/resources/image.rs
+++ b/src/v1/resources/image.rs
@@ -120,10 +120,9 @@ pub enum ImageStyle {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "snake_case")]
 pub enum ResponseFormat {
-    #[serde(rename = "url")]
     Url,
-    #[serde(rename = "b64_json")]
     B64Json,
 }
 

--- a/src/v1/resources/shared.rs
+++ b/src/v1/resources/shared.rs
@@ -80,6 +80,7 @@ pub struct DeletedObject {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "snake_case")]
 pub enum FinishReason {
     /// API returned complete message, or a message terminated by one of the stop sequences provided via the stop parameter.
     #[serde(rename = "stop")]
@@ -91,10 +92,8 @@ pub enum FinishReason {
     #[serde(rename = "content_filter")]
     ContentFilterFlagged,
     /// The model decided to call one or more tools.
-    #[serde(rename = "tool_calls")]
     ToolCalls,
     /// The model reached a natural stopping point. [Claude]
-    #[serde(rename = "end_turn")]
     EndTurn,
 }
 


### PR DESCRIPTION
Using snake_case rename automatically renames Snake to snake and SnakeCase to snake_case. This way some per-field renames can be dropped.