### PR TITLE
audio/image: use strum's EnumString

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,6 +275,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
 name = "http"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -545,6 +551,8 @@ dependencies = [
  "reqwest-eventsource",
  "serde",
  "serde_json",
+ "strum",
+ "strum_macros",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -838,6 +846,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80af6f9131f277a45a3fba6ce8e2258037bb0477a67e610d3c1fe046ab31de47"
+
+[[package]]
 name = "ryu"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -948,6 +962,25 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "strum"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
+
+[[package]]
+name = "strum_macros"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "subtle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,8 @@ rand = { version = "0.8", optional = true }
 base64 = { version = "0.22", optional = true }
 log = { version = "0.4", optional = true }
 bytes = "1.5.0"
+strum = "0.26.2"
+strum_macros = "0.26.2"
 
 [features]
 default = ["reqwest", "tokio", "tokio-util", "reqwest/default-tls"]

--- a/src/v1/resources/audio.rs
+++ b/src/v1/resources/audio.rs
@@ -2,6 +2,7 @@ use crate::v1::error::APIError;
 use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 use std::{fmt::Display, path::Path};
+use strum_macros::EnumString;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct AudioSpeechParameters {
@@ -94,7 +95,7 @@ pub struct AudioSpeechResponseChunkResponse {
     pub bytes: Bytes,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, EnumString, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum AudioOutputFormat {
     Json,
@@ -104,7 +105,7 @@ pub enum AudioOutputFormat {
     Vtt,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, EnumString, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum AudioSpeechResponseFormat {
     Mp3,
@@ -127,7 +128,7 @@ pub enum AudioTranscriptionFile {
     File(String),
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, EnumString, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum AudioVoice {
     Alloy,
@@ -138,7 +139,7 @@ pub enum AudioVoice {
     Shimmer,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, EnumString, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum TimestampGranularity {
     Word,

--- a/src/v1/resources/image.rs
+++ b/src/v1/resources/image.rs
@@ -8,6 +8,7 @@ use base64::{engine::general_purpose, Engine as _};
 use futures::future;
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
+use strum_macros::EnumString;
 
 #[derive(Serialize, Debug, Clone)]
 pub struct CreateImageParameters {
@@ -98,7 +99,7 @@ pub struct ImageResponse {
     pub data: Vec<ImageData>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, EnumString, PartialEq)]
 pub enum ImageSize {
     #[serde(rename = "256x256")]
     Size256X256,
@@ -112,21 +113,21 @@ pub enum ImageSize {
     Size1024X1792,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, EnumString, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum ImageStyle {
     Vivid,
     Natural,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, EnumString, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum ResponseFormat {
     Url,
     B64Json,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, EnumString, PartialEq)]
 #[serde(untagged)]
 pub enum ImageData {
     Url {


### PR DESCRIPTION
AudioTranscription requests are HTTP multipart requests, so we cannot use JSON deserialization unless with hacks like this:

  let response_format: AudioOutputFormat = serde_json::from_str(&format!("\"{response_format}\""))?;

Use strum's EnumString to allow deserializing Enum variants from str directly. This way, deserializing becomes much cleaner:

  let response_format = AudioOutputFormat::from_str(&response_format)?;