### PR TITLE
Introduce FileUpload to make file uploading consistent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,15 +52,9 @@ checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
-version = "2.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "bumpalo"
@@ -73,6 +67,9 @@ name = "bytes"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cc"
@@ -173,9 +170,9 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -194,9 +191,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
 name = "fnv"
@@ -490,12 +487,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
 name = "libc"
 version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -503,9 +494,9 @@ checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "log"
@@ -563,11 +554,10 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
 dependencies = [
- "lazy_static",
  "libc",
  "log",
  "openssl",
@@ -624,11 +614,11 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.63"
+version = "0.10.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15c9d69dd87a29568d4d017cfe8ec518706046a05184e5aea92d0af890b803c8"
+checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -656,9 +646,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.99"
+version = "0.9.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e1bf214306098e4832460f797824c05d25aacdf896f64a985fb0fd992454ae"
+checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
 dependencies = [
  "cc",
  "libc",
@@ -706,9 +696,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "proc-macro2"
@@ -726,15 +716,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
-dependencies = [
- "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -822,11 +803,11 @@ checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustix"
-version = "0.38.31"
+version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -890,11 +871,11 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.9.2"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -903,9 +884,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.9.1"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
+checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1016,13 +997,12 @@ checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "tempfile"
-version = "3.9.0"
+version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall",
  "rustix",
  "windows-sys 0.52.0",
 ]
@@ -1364,7 +1344,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -1384,17 +1364,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.0"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.0",
- "windows_aarch64_msvc 0.52.0",
- "windows_i686_gnu 0.52.0",
- "windows_i686_msvc 0.52.0",
- "windows_x86_64_gnu 0.52.0",
- "windows_x86_64_gnullvm 0.52.0",
- "windows_x86_64_msvc 0.52.0",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -1405,9 +1386,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1417,9 +1398,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1429,9 +1410,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1441,9 +1428,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1453,9 +1440,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1465,9 +1452,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1477,9 +1464,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.0"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
 base64 = { version = "0.22", optional = true }
 log = { version = "0.4", optional = true }
-bytes = "1.5.0"
+bytes = { version = "1.5.0", features = ["serde"] }
 derive_builder = "0.20.0"
 
 [features]

--- a/src/v1/endpoints/audio.rs
+++ b/src/v1/endpoints/audio.rs
@@ -1,13 +1,10 @@
 use crate::v1::api::Client;
 use crate::v1::error::APIError;
-use crate::v1::helpers::{file_from_bytes_to_form_part, file_from_disk_to_form_part};
 use crate::v1::resources::audio::AudioSpeechParameters;
 use crate::v1::resources::audio::AudioSpeechResponse;
 #[cfg(feature = "stream")]
 use crate::v1::resources::audio::AudioSpeechResponseChunkResponse;
-use crate::v1::resources::audio::{
-    AudioTranscriptionFile, AudioTranscriptionParameters, AudioTranslationParameters,
-};
+use crate::v1::resources::audio::{AudioTranscriptionParameters, AudioTranslationParameters};
 #[cfg(feature = "stream")]
 use futures::Stream;
 #[cfg(feature = "stream")]
@@ -44,10 +41,7 @@ impl Audio<'_> {
     ) -> Result<String, APIError> {
         let mut form = reqwest::multipart::Form::new();
 
-        let file = match parameters.file {
-            AudioTranscriptionFile::Bytes(b) => file_from_bytes_to_form_part(b)?,
-            AudioTranscriptionFile::File(f) => file_from_disk_to_form_part(f).await?,
-        };
+        let file = parameters.file.into_part().await?;
 
         form = form.part("file", file);
 
@@ -95,7 +89,7 @@ impl Audio<'_> {
     ) -> Result<String, APIError> {
         let mut form = reqwest::multipart::Form::new();
 
-        let file = file_from_disk_to_form_part(parameters.file).await?;
+        let file = parameters.file.into_part().await?;
         form = form.part("file", file);
 
         form = form.text("model", parameters.model);

--- a/src/v1/endpoints/files.rs
+++ b/src/v1/endpoints/files.rs
@@ -1,6 +1,5 @@
 use crate::v1::api::Client;
 use crate::v1::error::APIError;
-use crate::v1::helpers::file_from_disk_to_form_part;
 use crate::v1::helpers::format_response;
 use crate::v1::resources::file::ListFilesParameters;
 use crate::v1::resources::file::ListFilesResponse;
@@ -35,7 +34,7 @@ impl Files<'_> {
     pub async fn upload(&self, parameters: UploadFileParameters) -> Result<File, APIError> {
         let mut form = reqwest::multipart::Form::new();
 
-        let file = file_from_disk_to_form_part(parameters.file).await?;
+        let file = parameters.file.into_part().await?;
         form = form.part("file", file);
 
         form = form.text("purpose", parameters.purpose.to_string());

--- a/src/v1/endpoints/images.rs
+++ b/src/v1/endpoints/images.rs
@@ -1,6 +1,6 @@
 use crate::v1::api::Client;
 use crate::v1::error::APIError;
-use crate::v1::helpers::{file_from_disk_to_form_part, format_response};
+use crate::v1::helpers::format_response;
 use crate::v1::resources::image::{
     CreateImageParameters, CreateImageVariationParameters, EditImageParameters, ImageResponse,
 };
@@ -33,13 +33,13 @@ impl Images<'_> {
     pub async fn edit(&self, parameters: EditImageParameters) -> Result<ImageResponse, APIError> {
         let mut form = reqwest::multipart::Form::new();
 
-        let image = file_from_disk_to_form_part(parameters.image).await?;
+        let image = parameters.image.into_part().await?;
         form = form.part("image", image);
 
         form = form.text("prompt", parameters.prompt);
 
         if let Some(mask) = parameters.mask {
-            let image = file_from_disk_to_form_part(mask).await?;
+            let image = mask.into_part().await?;
             form = form.part("mask", image);
         }
 
@@ -77,7 +77,7 @@ impl Images<'_> {
     ) -> Result<ImageResponse, APIError> {
         let mut form = reqwest::multipart::Form::new();
 
-        let image = file_from_disk_to_form_part(parameters.image).await?;
+        let image = parameters.image.into_part().await?;
         form = form.part("image", image);
 
         if let Some(model) = parameters.model {

--- a/src/v1/helpers.rs
+++ b/src/v1/helpers.rs
@@ -1,12 +1,9 @@
 use crate::v1::error::APIError;
-use crate::v1::resources::audio::AudioTranscriptionBytes;
-use reqwest::{multipart::Part, Response, StatusCode};
+use reqwest::{Response, StatusCode};
 use serde::de::DeserializeOwned;
 use serde_json::Value;
 #[cfg(feature = "download")]
 use std::time::{SystemTime, UNIX_EPOCH};
-use tokio::fs::File;
-use tokio_util::codec::{BytesCodec, FramedRead};
 
 pub async fn check_status_code(result: reqwest::Result<Response>) -> Result<Response, APIError> {
     match result {
@@ -57,29 +54,6 @@ pub fn format_response<R: DeserializeOwned>(response: String) -> Result<R, APIEr
 
 pub fn is_beta_feature(path: &str) -> bool {
     path.starts_with("/assistants") || path.starts_with("/threads")
-}
-
-pub fn file_from_bytes_to_form_part(input: AudioTranscriptionBytes) -> Result<Part, APIError> {
-    reqwest::multipart::Part::bytes(input.bytes.to_vec())
-        .file_name(input.filename)
-        .mime_str("application/octet-stream")
-        .map_err(|error| APIError::FileError(error.to_string()))
-}
-
-pub async fn file_from_disk_to_form_part(path: String) -> Result<Part, APIError> {
-    let file = File::open(&path)
-        .await
-        .map_err(|error| APIError::FileError(error.to_string()))?;
-
-    let stream = FramedRead::new(file, BytesCodec::new());
-    let file_body = reqwest::Body::wrap_stream(stream);
-
-    let file_part = reqwest::multipart::Part::stream(file_body)
-        .file_name(path)
-        .mime_str("application/octet-stream")
-        .unwrap();
-
-    Ok(file_part)
 }
 
 #[cfg(feature = "download")]

--- a/src/v1/resources/audio.rs
+++ b/src/v1/resources/audio.rs
@@ -1,8 +1,12 @@
+#[cfg(feature = "tokio")]
 use crate::v1::error::APIError;
+use crate::v1::resources::shared::FileUpload;
 use bytes::Bytes;
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
-use std::{fmt::Display, path::Path};
+use std::fmt::Display;
+#[cfg(feature = "tokio")]
+use std::path::Path;
 
 #[derive(Serialize, Deserialize, Debug, Default, Builder, Clone, PartialEq)]
 #[builder(name = "AudioSpeechParametersBuilder")]
@@ -27,8 +31,7 @@ pub struct AudioSpeechParameters {
 #[builder(setter(into, strip_option), default)]
 pub struct AudioTranscriptionParameters {
     /// The audio file object (not file name) to transcribe, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
-    #[serde(skip)]
-    pub file: AudioTranscriptionFile,
+    pub file: FileUpload,
     /// ID of the model to use. Only whisper-1 is currently available.
     pub model: String,
     /// The language of the input audio. Supplying the input language in ISO-639-1 format will improve accuracy and latency.
@@ -55,8 +58,8 @@ pub struct AudioTranscriptionParameters {
 #[builder(name = "AudioTranslationParametersBuilder")]
 #[builder(setter(into, strip_option), default)]
 pub struct AudioTranslationParameters {
-    /// The audio file object (not file name) translate, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
-    pub file: String,
+    /// The audio file object to translate, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
+    pub file: FileUpload,
     /// ID of the model to use. Only whisper-1 is currently available.
     pub model: String,
     /// An optional text to guide the model's style or continue a previous audio segment. The prompt should be in English.
@@ -120,18 +123,6 @@ pub enum AudioSpeechResponseFormat {
     Flac,
     Wav,
     Pcm,
-}
-
-#[derive(Clone, Debug, PartialEq)]
-pub struct AudioTranscriptionBytes {
-    pub bytes: Bytes,
-    pub filename: String,
-}
-
-#[derive(Clone, Debug, PartialEq)]
-pub enum AudioTranscriptionFile {
-    Bytes(AudioTranscriptionBytes),
-    File(String),
 }
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
@@ -204,11 +195,5 @@ impl AudioSpeechResponse {
             .map_err(|error| APIError::FileError(error.to_string()))?;
 
         Ok(())
-    }
-}
-
-impl Default for AudioTranscriptionFile {
-    fn default() -> Self {
-        Self::File(String::new())
     }
 }

--- a/src/v1/resources/file.rs
+++ b/src/v1/resources/file.rs
@@ -1,3 +1,4 @@
+use crate::v1::resources::shared::FileUpload;
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
@@ -36,8 +37,8 @@ pub struct ListFilesResponse {
 #[builder(name = "UploadFileParametersBuilder")]
 #[builder(setter(into, strip_option), default)]
 pub struct UploadFileParameters {
-    /// The File object (not file name) to be uploaded.
-    pub file: String,
+    /// The File object to be uploaded.
+    pub file: FileUpload,
     /// The intended purpose of the uploaded file.
     /// Use "assistants" for Assistants and Message files, "vision" for Assistants image file inputs,
     /// "batch" for Batch API, and "fine-tune" for Fine-tuning.

--- a/src/v1/resources/image.rs
+++ b/src/v1/resources/image.rs
@@ -2,6 +2,7 @@
 use crate::v1::error::APIError;
 #[cfg(feature = "download")]
 use crate::v1::helpers::generate_file_name;
+use crate::v1::resources::shared::FileUpload;
 #[cfg(feature = "download")]
 use base64::{engine::general_purpose, Engine as _};
 use derive_builder::Builder;
@@ -49,13 +50,13 @@ pub struct CreateImageParameters {
 #[builder(setter(into, strip_option), default)]
 pub struct EditImageParameters {
     /// The image to edit. Must be a valid PNG file, less than 4MB, and square. If mask is not provided, image must have transparency, which will be used as the mask.
-    pub image: String,
+    pub image: FileUpload,
     /// A text description of the desired image(s). The maximum length is 1000 characters.
     pub prompt: String,
     /// An additional image whose fully transparent areas (e.g. where alpha is zero) indicate where image should be edited.
     /// Must be a valid PNG file, less than 4MB, and have the same dimensions as image.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub mask: Option<String>,
+    pub mask: Option<FileUpload>,
     /// The model to use for image generation. Only dall-e-2 is supported at this time.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
@@ -78,7 +79,7 @@ pub struct EditImageParameters {
 #[builder(setter(into, strip_option), default)]
 pub struct CreateImageVariationParameters {
     /// The image to use as the basis for the variation(s). Must be a valid PNG file, less than 4MB, and square.
-    pub image: String,
+    pub image: FileUpload,
     /// The model to use for image generation. Only dall-e-2 is supported at this time.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,


### PR DESCRIPTION
`AudioTranscriptionParameters` allowed for uploading in-memory bytes using `AudioTranscriptionFile`, but none of the other endpoints exposing files did. 

This PR fixes that by renaming `AudioTranscriptionFile` to `FileUpload` and switching the other endpoints over to using it.

This was actually a side-effect of the actual change I wanted to make, which was to make it possible to build the crate with `reqwest` but without `tokio`. This achieves that by isolating the `tokio`-using code to `FileUpload::File` and conditionally compiling that.

This compiles with:
- `cargo clippy`
- `cargo clippy --no-default-features`
- `cargo clippy --no-default-features -F reqwest`