### PR TITLE
Fix `post_with_form` not building under WASM

### DIFF
--- a/.github/workflows/cargo-build.yml
+++ b/.github/workflows/cargo-build.yml
@@ -36,3 +36,14 @@ jobs:
     - uses: actions/checkout@v3
     - name: Build
       run: cargo build --verbose --no-default-features --features reqwest
+
+  cargo-build-without-default-features-with-reqwest-on-wasm32:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install wasm32 target
+      run: rustup target add wasm32-unknown-unknown
+    - name: Build
+      run: cargo build --verbose --target wasm32-unknown-unknown --no-default-features --features reqwest

--- a/src/v1/api.rs
+++ b/src/v1/api.rs
@@ -164,12 +164,13 @@ impl Client {
     }
 
     pub async fn post_with_form(&self, path: &str, form: Form) -> Result<String, APIError> {
+        #[cfg(not(target_arch = "wasm32"))]
+        let content_type = format!("multipart/form-data; boundary={}", form.boundary());
+        #[cfg(target_arch = "wasm32")]
+        let content_type = format!("multipart/form-data");
+
         let result = self
-            .build_request(
-                Method::POST,
-                path,
-                format!("multipart/form-data; boundary={}", form.boundary()).as_str(),
-            )
+            .build_request(Method::POST, path, &content_type)
             .multipart(form)
             .send()
             .await;


### PR DESCRIPTION
The current HEAD fails to build under WASM as `Form::boundary()` doesn't exist in the WASM version of `reqwest`, as it seems like the browser will automatically provide this: <https://github.com/seanmonstar/reqwest/issues/1958#issuecomment-1698170136>

This PR fixes that by only including the boundary on non-WASM. I've also added another GH job that builds under WASM to make it easier to check this kind of thing (there are lots of fun divergences on WASM 😢)

You may want to consider splitting the workflow up so that they can run in parallel at some point; I considered doing this but figured it'd be safer to be conservative in my change.

**EDIT**: Wow, the CI is pretty quick. Alright, splitting it up's probably not a priority 😅 