### PR TITLE
Make Clippy fail CI and fix existing warnings

### DIFF
--- a/.github/workflows/cargo-clippy.yml
+++ b/.github/workflows/cargo-clippy.yml
@@ -17,4 +17,4 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Cargo clippy
-      run: cargo clippy --tests --workspace --all-targets
+      run: cargo clippy --tests --workspace --all-targets -- -Dwarnings

--- a/openai_dive/src/v1/api.rs
+++ b/openai_dive/src/v1/api.rs
@@ -205,10 +205,10 @@ impl Client {
             Err(error) => return Err(error),
         };
 
-        Ok(response
+        response
             .text()
             .await
-            .map_err(|error| APIError::ParseError(error.to_string()))?)
+            .map_err(|error| APIError::ParseError(error.to_string()))
     }
 
     pub(crate) async fn post_with_form(&self, path: &str, form: Form) -> Result<String, APIError> {
@@ -228,10 +228,10 @@ impl Client {
             Err(error) => return Err(error),
         };
 
-        Ok(response
+        response
             .text()
             .await
-            .map_err(|error| APIError::ParseError(error.to_string()))?)
+            .map_err(|error| APIError::ParseError(error.to_string()))
     }
 
     pub(crate) async fn post_raw<T: Serialize>(
@@ -250,10 +250,10 @@ impl Client {
             Err(error) => return Err(error),
         };
 
-        Ok(response
+        response
             .bytes()
             .await
-            .map_err(|error| APIError::ParseError(error.to_string()))?)
+            .map_err(|error| APIError::ParseError(error.to_string()))
     }
 
     #[cfg(feature = "stream")]


### PR DESCRIPTION
While creating #85, I noticed Clippy produced some warnings; this fixes those warnings and makes them fail CI, so that it's more obvious when they occur.