### PR TITLE
bugfix: make `parallel_tool_calls` be a public member

### DIFF
--- a/openai_dive/src/v1/resources/chat.rs
+++ b/openai_dive/src/v1/resources/chat.rs
@@ -128,7 +128,7 @@ pub struct ChatCompletionParameters {
     pub tool_choice: Option<ChatCompletionToolChoice>,
     /// Whether to enable parallel function calling during tool use.
     #[serde(skip_serializing_if = "Option::is_none")]
-    parallel_tool_calls: Option<bool>,
+    pub parallel_tool_calls: Option<bool>,
     /// A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<String>,

--- a/openai_dive/src/v1/resources/shared.rs
+++ b/openai_dive/src/v1/resources/shared.rs
@@ -136,7 +136,7 @@ pub enum LastErrorCode {
 #[serde(rename_all = "snake_case")]
 pub enum FinishReason {
     /// API returned complete message, or a message terminated by one of the stop sequences provided via the stop parameter.
-    #[serde(rename = "stop")]
+    #[serde(rename = "stop", alias = "STOP")]
     StopSequenceReached,
     /// Incomplete model output due to max_tokens parameter or token limit.
     #[serde(rename = "length")]

--- a/openai_dive/src/v1/resources/shared.rs
+++ b/openai_dive/src/v1/resources/shared.rs
@@ -139,15 +139,29 @@ pub enum FinishReason {
     #[serde(rename = "stop", alias = "STOP")]
     StopSequenceReached,
     /// Incomplete model output due to max_tokens parameter or token limit.
-    #[serde(rename = "length")]
+    #[serde(rename = "length", alias = "MAX_TOKENS")]
     TokenLimitReached,
     /// Omitted content due to a flag from our content filters.
-    #[serde(rename = "content_filter")]
+    #[serde(
+        rename = "content_filter",
+        alias = "SAFETY",
+        alias = "SPII",
+        alias = "PROHIBITED_CONTENT",
+        alias = "BLOCKLIST",
+        alias = "RECITATION"
+    )]
     ContentFilterFlagged,
     /// The model decided to call one or more tools.
     ToolCalls,
     /// The model reached a natural stopping point. [Claude]
     EndTurn,
+    /// The finish reason is unspecified. [Gemini]
+    #[serde(rename = "FINISH_REASON_UNSPECIFIED	")]
+    FinishReasonUnspecified,
+    #[serde(rename = "MALFORMED_FUNCTION_CALL")]
+    MalformedFunctionCall,
+    #[serde(rename = "OTHER")]
+    Other,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]


### PR DESCRIPTION
Two bugfixes:
- One is from the issue seen in `ChatCompletionParameters` and using `..Default::default()`. I'm not sure why `parallel_tool_calls` is a private member as it doesn't seem to be used anywhere internally. 

![image](https://github.com/user-attachments/assets/5ff6aa10-875c-4443-81c7-ae2b35d5493c)

- The other is from gemini-flash returning `STOP` instead of `stop` as the stop token
