### PR TITLE
Add usage to ChatCompletionChunkResponse

### DIFF
--- a/openai_dive/src/v1/resources/chat.rs
+++ b/openai_dive/src/v1/resources/chat.rs
@@ -46,6 +46,9 @@ pub struct ChatCompletionChunkResponse {
     pub system_fingerprint: Option<String>,
     /// The object type, which is always chat.completion.chunk.
     pub object: String,
+    /// An optional field that will only be present when you set stream_options: {"include_usage": true} in your request. When present, it contains a null value except for the last chunk which contains the token usage statistics for the entire request.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub usage: Option<Usage>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Default, Builder, Clone, PartialEq)]


### PR DESCRIPTION
When using the chat endpoint in streaming mode, the include_usage stream option enables to get the usage data in an additional chunk (with choices as an empty array), as specified in the OpenAI API reference: https://platform.openai.com/docs/api-reference/chat/streaming#chat/streaming-usage

This PR adds the usage field to ChatCompletionChunkResponse so that the usage data is deserialized in that case.