### PR TITLE
workaround for mistral ai missing tool type

### DIFF
--- a/openai_dive/src/v1/resources/chat.rs
+++ b/openai_dive/src/v1/resources/chat.rs
@@ -365,9 +365,13 @@ pub struct ToolCall {
     /// The ID of the tool call.
     pub id: String,
     /// The type of the tool. Currently, only function is supported.
+    #[serde(default = "default_tool_type")]
     pub r#type: String,
     /// The function that the model called.
     pub function: Function,
+}
+fn default_tool_type() -> String {
+    "function".to_string()
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]


### PR DESCRIPTION
I needed this change in order to use this crate with [Mistral AI](https://mistral.ai/) because their API does not include a tool type in the responses.
With this small change I was able to use this crate with their API by just changing URL and model.