### PR TITLE
`ResponseOutput::Reasoning` is renamed to `"computer_call"` during serialization

### DIFF
--- a/openai_dive/src/v1/resources/response/response.rs
+++ b/openai_dive/src/v1/resources/response/response.rs
@@ -80,7 +80,7 @@ pub enum ResponseOutput {
     FileSearchToolCall(FileSearchToolCall),
     #[serde(rename = "web_search_call")]
     WebSearchToolCall(WebSearchToolCall),
-    #[serde(rename = "computer_call")]
+    // #[serde(rename = "computer_call")]
     // ComputerToolCall(ComputerToolCall),
     Reasoning(Reasoning),
 }


### PR DESCRIPTION
There was an oversight when commenting out the ComputerToolCall variant below:

```rust
#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
#[serde(tag = "type", rename_all = "snake_case")]
pub enum ResponseOutput {
    Message(OutputMessage),
    #[serde(rename = "function_call")]
    FunctionToolCall(FunctionToolCall),
    #[serde(rename = "file_search_call")]
    FileSearchToolCall(FileSearchToolCall),
    #[serde(rename = "web_search_call")]
    WebSearchToolCall(WebSearchToolCall),
    #[serde(rename = "computer_call")]
    // ComputerToolCall(ComputerToolCall),
    Reasoning(Reasoning),
}
```

Now the serde rename is also commented out:
```rust
...
    WebSearchToolCall(WebSearchToolCall),
    // #[serde(rename = "computer_call")]
    // ComputerToolCall(ComputerToolCall),
    Reasoning(Reasoning),
}
```