### PR TITLE
Add serde tag to ContentItem

### DIFF
--- a/openai_dive/src/v1/resources/response/request.rs
+++ b/openai_dive/src/v1/resources/response/request.rs
@@ -85,6 +85,7 @@ pub enum ContentInput {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(tag = "type")]
 pub enum ContentItem {
     #[serde(rename = "input_text")]
     Text { text: String },


### PR DESCRIPTION
I noticed that I was running into an error related to content type while using the new Responses API, and that another repo had `#[serde(tag = "type")]` on an equivalent enum. Adding it here fixed the issue.

```
"error": {
  "message": "Missing required parameter: 'input[0].content[0].type'.",
  "type": "invalid_request_error",
  "param": "input[0].content[0].type",
  "code": "missing_required_parameter"
}
```