### PR TITLE
Chat completion response format deserialization is not working as expected

### DIFF
--- a/examples/chat/structured_outputs/src/main.rs
+++ b/examples/chat/structured_outputs/src/main.rs
@@ -26,31 +26,33 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 name: None,
             },
         ])
-        .response_format(ChatCompletionResponseFormat::JsonSchema(JsonSchemaBuilder::default()
-            .name("math_reasoning")
-            .schema(serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "steps": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "explanation": { "type": "string" },
-                                "output": { "type": "string" }
-                            },
-                            "required": ["explanation", "output"],
-                            "additionalProperties": false
-                        }
+        .response_format(ChatCompletionResponseFormat::JsonSchema { 
+            json_schema: JsonSchemaBuilder::default()
+                .name("math_reasoning")
+                .schema(serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "steps": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "explanation": { "type": "string" },
+                                    "output": { "type": "string" }
+                                },
+                                "required": ["explanation", "output"],
+                                "additionalProperties": false
+                            }
+                        },
+                        "final_answer": { "type": "string" }
                     },
-                    "final_answer": { "type": "string" }
-                },
-                "required": ["steps", "final_answer"],
-                "additionalProperties": false
-            }))
-            .strict(true)
-            .build()?
-        ))
+                    "required": ["steps", "final_answer"],
+                    "additionalProperties": false
+                }))
+                .strict(true)
+                .build()?
+            }
+        )
         .build()?;
 
     let result = client.chat().create(parameters).await?;

--- a/openai_dive/README.md
+++ b/openai_dive/README.md
@@ -264,31 +264,33 @@ let parameters = ChatCompletionParametersBuilder::default()
             name: None,
         },
     ])
-    .response_format(ChatCompletionResponseFormat::JsonSchema(JsonSchemaBuilder::default()
-        .name("math_reasoning")
-        .schema(serde_json::json!({
-            "type": "object",
-            "properties": {
-                "steps": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "explanation": { "type": "string" },
-                            "output": { "type": "string" }
-                        },
-                        "required": ["explanation", "output"],
-                        "additionalProperties": false
-                    }
+    .response_format(ChatCompletionResponseFormat::JsonSchema { 
+        json_schema: JsonSchemaBuilder::default()
+            .name("math_reasoning")
+            .schema(serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "steps": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "explanation": { "type": "string" },
+                                "output": { "type": "string" }
+                            },
+                            "required": ["explanation", "output"],
+                            "additionalProperties": false
+                        }
+                    },
+                    "final_answer": { "type": "string" }
                 },
-                "final_answer": { "type": "string" }
-            },
-            "required": ["steps", "final_answer"],
-            "additionalProperties": false
-        }))
-        .strict(true)
-        .build()?
-    ))
+                "required": ["steps", "final_answer"],
+                "additionalProperties": false
+            }))
+            .strict(true)
+            .build()?
+        }
+    )
     .build()?;
 
 let result = client.chat().create(parameters).await?;

--- a/openai_dive/src/lib.rs
+++ b/openai_dive/src/lib.rs
@@ -259,31 +259,33 @@
 //!             name: None,
 //!         },
 //!     ])
-//!     .response_format(ChatCompletionResponseFormat::JsonSchema(JsonSchemaBuilder::default()
-//!         .name("math_reasoning")
-//!         .schema(serde_json::json!({
-//!             "type": "object",
-//!             "properties": {
-//!                 "steps": {
-//!                     "type": "array",
-//!                     "items": {
-//!                         "type": "object",
-//!                         "properties": {
-//!                             "explanation": { "type": "string" },
-//!                             "output": { "type": "string" }
-//!                         },
-//!                         "required": ["explanation", "output"],
-//!                         "additionalProperties": false
-//!                     }
+//!     .response_format(ChatCompletionResponseFormat::JsonSchema { 
+//!         json_schema: JsonSchemaBuilder::default()
+//!             .name("math_reasoning")
+//!             .schema(serde_json::json!({
+//!                 "type": "object",
+//!                 "properties": {
+//!                     "steps": {
+//!                         "type": "array",
+//!                         "items": {
+//!                             "type": "object",
+//!                             "properties": {
+//!                                 "explanation": { "type": "string" },
+//!                                 "output": { "type": "string" }
+//!                             },
+//!                             "required": ["explanation", "output"],
+//!                             "additionalProperties": false
+//!                         }
+//!                     },
+//!                     "final_answer": { "type": "string" }
 //!                 },
-//!                 "final_answer": { "type": "string" }
-//!             },
-//!             "required": ["steps", "final_answer"],
-//!             "additionalProperties": false
-//!         }))
-//!         .strict(true)
-//!         .build()?
-//!     ))
+//!                 "required": ["steps", "final_answer"],
+//!                 "additionalProperties": false
+//!             }))
+//!             .strict(true)
+//!             .build()?
+//!         }
+//!     )
 //!     .build()?;
 //!
 //! let result = client.chat().create(parameters).await?;

--- a/openai_dive/src/v1/resources/chat.rs
+++ b/openai_dive/src/v1/resources/chat.rs
@@ -197,9 +197,10 @@ pub enum ChatCompletionResponseFormat {
     Text,
     JsonObject,
     JsonSchema {
-        JsonSchema
+        json_schema: JsonSchema
     },
 }
+
 
 #[derive(Serialize, Deserialize, Debug, Default, Builder, Clone, PartialEq)]
 #[builder(name = "JsonSchemaBuilder")]

--- a/openai_dive/src/v1/resources/chat.rs
+++ b/openai_dive/src/v1/resources/chat.rs
@@ -1,8 +1,7 @@
 use crate::v1::resources::shared::StopToken;
 use crate::v1::resources::shared::{FinishReason, Usage};
 use derive_builder::Builder;
-use serde::ser::SerializeStruct;
-use serde::{Deserialize, Serialize, Serializer};
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt::Display;
 
@@ -192,38 +191,14 @@ pub struct ChatCompletionFunction {
     pub parameters: serde_json::Value,
 }
 
-#[derive(Deserialize, Debug, Clone, PartialEq)]
-#[serde(rename_all = "snake_case")]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
 pub enum ChatCompletionResponseFormat {
     Text,
     JsonObject,
-    JsonSchema(JsonSchema),
-}
-
-impl Serialize for ChatCompletionResponseFormat {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        match self {
-            ChatCompletionResponseFormat::Text => {
-                let mut state = serializer.serialize_struct("ChatCompletionResponseFormat", 1)?;
-                state.serialize_field("type", "text")?;
-                state.end()
-            }
-            ChatCompletionResponseFormat::JsonObject => {
-                let mut state = serializer.serialize_struct("ChatCompletionResponseFormat", 1)?;
-                state.serialize_field("type", "json_object")?;
-                state.end()
-            }
-            ChatCompletionResponseFormat::JsonSchema(json_schema) => {
-                let mut state = serializer.serialize_struct("ChatCompletionResponseFormat", 2)?;
-                state.serialize_field("type", "json_schema")?;
-                state.serialize_field("json_schema", json_schema)?;
-                state.end()
-            }
-        }
-    }
+    JsonSchema {
+        JsonSchema
+    },
 }
 
 #[derive(Serialize, Deserialize, Debug, Default, Builder, Clone, PartialEq)]

--- a/openai_dive/src/v1/resources/chat.rs
+++ b/openai_dive/src/v1/resources/chat.rs
@@ -201,7 +201,6 @@ pub enum ChatCompletionResponseFormat {
     },
 }
 
-
 #[derive(Serialize, Deserialize, Debug, Default, Builder, Clone, PartialEq)]
 #[builder(name = "JsonSchemaBuilder")]
 #[builder(setter(into, strip_option), default)]
@@ -677,5 +676,42 @@ impl DeltaFunction {
 
     pub fn is_empty(&self) -> bool {
         self.name.is_none() && self.arguments.is_none()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::v1::resources::chat::{ChatCompletionResponseFormat, JsonSchema, JsonSchemaBuilder};
+    use serde_json;
+
+    #[test]
+    fn test_chat_completion_response_format_serialization_deserialization() {
+        let json_schema = JsonSchemaBuilder::default()
+            .description("This is a test schema".to_string())
+            .name("test_schema".to_string())
+            .schema(Some(serde_json::json!({"type": "object"})))
+            .strict(true)
+            .build()
+            .unwrap();
+
+        let response_format = ChatCompletionResponseFormat::JsonSchema {
+            json_schema,
+        };
+
+        // Serialize the response format to a JSON string
+        let serialized = serde_json::to_string(&response_format).unwrap();
+        assert_eq!(serialized, "{\"type\":\"json_schema\",\"json_schema\":{\"description\":\"This is a test schema\",\"name\":\"test_schema\",\"schema\":{\"type\":\"object\"},\"strict\":true}}");
+
+        // Deserialize the JSON string back to a ChatCompletionResponseFormat
+        let deserialized: ChatCompletionResponseFormat = serde_json::from_str(&serialized).unwrap();
+        match deserialized {
+            ChatCompletionResponseFormat::JsonSchema { json_schema } => {
+                assert_eq!(json_schema.description, Some("This is a test schema".to_string()));
+                assert_eq!(json_schema.name, "test_schema".to_string());
+                assert_eq!(json_schema.schema, Some(serde_json::json!({"type": "object"})));
+                assert_eq!(json_schema.strict, Some(true));
+            },
+            _ => panic!("Deserialized format should be JsonSchema"),
+        }
     }
 }


### PR DESCRIPTION
Currently, the deserialization of the ResponseFormat struct is not working as expected. 

The following test that tries to deserialize a serialized ChatCompletionResponseFormat should work but currently fails on the master branch:
```
#[cfg(test)]
mod tests {
    use crate::v1::resources::chat::{ChatCompletionResponseFormat, JsonSchemaBuilder};
    use serde_json;

    #[test]
    fn test_chat_completion_response_format_serialization_deserialization() {
        let json_schema = JsonSchemaBuilder::default()
            .description("This is a test schema".to_string())
            .name("test_schema".to_string())
            .schema(Some(serde_json::json!({"type": "object"})))
            .strict(true)
            .build()
            .unwrap();

        let response_format = ChatCompletionResponseFormat::JsonSchema(json_schema);

        // Serialize the response format to a JSON string
        let serialized = serde_json::to_string(&response_format).unwrap();
        assert_eq!(serialized, "{\"type\":\"json_schema\",\"json_schema\":{\"description\":\"This is a test schema\",\"name\":\"test_schema\",\"schema\":{\"type\":\"object\"},\"strict\":true}}");

        // Deserialize the JSON string back to a ChatCompletionResponseFormat
        let deserialized: ChatCompletionResponseFormat = serde_json::from_str(&serialized).unwrap();
        match deserialized {
            ChatCompletionResponseFormat::JsonSchema(json_schema) => {
                assert_eq!(json_schema.description, Some("This is a test schema".to_string()));
                assert_eq!(json_schema.name, "test_schema".to_string());
                assert_eq!(json_schema.schema, Some(serde_json::json!({"type": "object"})));
                assert_eq!(json_schema.strict, Some(true));
            },
            _ => panic!("Deserialized format should be JsonSchema"),
        }
    }
}
```

This PR fixes this by using the internal tag feature of serde: https://serde.rs/enum-representations.html#internally-tagged. This is the same approach that was used in the newly implemented ResponseFormat struct for the /responses API.
The main drawback of this approach is that it is a breaking change on the current usage of the ChatCompletion.
```
# Before PR
        .response_format(ChatCompletionResponseFormat::JsonSchema(JsonSchemaBuilder::default()
        ...
# After PR
        .response_format(ChatCompletionResponseFormat::JsonSchema { 
            json_schema: JsonSchemaBuilder::default()
            ...
```
I have updated the docs and examples accordingly, but since this may cause some issue I will also provide another PR shortly that implements a custom Deserializer for the ChatCompletionResponseFormat struct.


