### PR TITLE
Fix the `ChatCompletionToolChoice` enum serialization

### DIFF
--- a/openai_dive/src/v1/resources/chat.rs
+++ b/openai_dive/src/v1/resources/chat.rs
@@ -679,7 +679,10 @@ impl DeltaFunction {
 
 #[cfg(test)]
 mod tests {
-    use crate::v1::resources::chat::{ChatCompletionResponseFormat, ChatCompletionToolChoice, ChatCompletionToolChoiceFunction, ChatCompletionToolChoiceFunctionName, ChatCompletionToolType, JsonSchemaBuilder};
+    use crate::v1::resources::chat::{
+        ChatCompletionResponseFormat, ChatCompletionToolChoice, ChatCompletionToolChoiceFunction,
+        ChatCompletionToolChoiceFunctionName, ChatCompletionToolType, JsonSchemaBuilder,
+    };
     use serde_json;
 
     #[test]
@@ -724,23 +727,30 @@ mod tests {
         let serialized = serde_json::to_string(&tool_choice).unwrap();
         assert_eq!(serialized, "\"required\"");
 
-        let deserialized: ChatCompletionToolChoice = serde_json::from_str(serialized.as_str()).unwrap();
+        let deserialized: ChatCompletionToolChoice =
+            serde_json::from_str(serialized.as_str()).unwrap();
         assert_eq!(deserialized, tool_choice)
     }
 
     #[test]
     fn test_chat_completion_tool_choice_named_function_serialization_deserialization() {
-        let tool_choice = ChatCompletionToolChoice::ChatCompletionToolChoiceFunction(ChatCompletionToolChoiceFunction {
-            r#type: Some(ChatCompletionToolType::Function),
-            function: ChatCompletionToolChoiceFunctionName {
-                name: "get_current_weather".to_string(),
+        let tool_choice = ChatCompletionToolChoice::ChatCompletionToolChoiceFunction(
+            ChatCompletionToolChoiceFunction {
+                r#type: Some(ChatCompletionToolType::Function),
+                function: ChatCompletionToolChoiceFunctionName {
+                    name: "get_current_weather".to_string(),
+                },
             },
-        });
+        );
 
         let serialized = serde_json::to_string(&tool_choice).unwrap();
-        assert_eq!(serialized, "{\"type\":\"function\",\"function\":{\"name\":\"get_current_weather\"}}");
+        assert_eq!(
+            serialized,
+            "{\"type\":\"function\",\"function\":{\"name\":\"get_current_weather\"}}"
+        );
 
-        let deserialized: ChatCompletionToolChoice = serde_json::from_str(serialized.as_str()).unwrap();
+        let deserialized: ChatCompletionToolChoice =
+            serde_json::from_str(serialized.as_str()).unwrap();
         assert_eq!(deserialized, tool_choice)
     }
 }

--- a/openai_dive/src/v1/resources/chat.rs
+++ b/openai_dive/src/v1/resources/chat.rs
@@ -606,11 +606,11 @@ pub enum ChatCompletionToolType {
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "lowercase")]
-#[serde(untagged)]
 pub enum ChatCompletionToolChoice {
     None,
     Auto,
     Required,
+    #[serde(untagged)]
     ChatCompletionToolChoiceFunction(ChatCompletionToolChoiceFunction),
 }
 

--- a/openai_dive/src/v1/resources/chat.rs
+++ b/openai_dive/src/v1/resources/chat.rs
@@ -679,7 +679,7 @@ impl DeltaFunction {
 
 #[cfg(test)]
 mod tests {
-    use crate::v1::resources::chat::{ChatCompletionResponseFormat, JsonSchemaBuilder};
+    use crate::v1::resources::chat::{ChatCompletionResponseFormat, ChatCompletionToolChoice, ChatCompletionToolChoiceFunction, ChatCompletionToolChoiceFunctionName, ChatCompletionToolType, JsonSchemaBuilder};
     use serde_json;
 
     #[test]
@@ -715,5 +715,32 @@ mod tests {
             }
             _ => panic!("Deserialized format should be JsonSchema"),
         }
+    }
+
+    #[test]
+    fn test_chat_completion_tool_choice_required_serialization_deserialization() {
+        let tool_choice = ChatCompletionToolChoice::Required;
+
+        let serialized = serde_json::to_string(&tool_choice).unwrap();
+        assert_eq!(serialized, "\"required\"");
+
+        let deserialized: ChatCompletionToolChoice = serde_json::from_str(serialized.as_str()).unwrap();
+        assert_eq!(deserialized, tool_choice)
+    }
+
+    #[test]
+    fn test_chat_completion_tool_choice_named_function_serialization_deserialization() {
+        let tool_choice = ChatCompletionToolChoice::ChatCompletionToolChoiceFunction(ChatCompletionToolChoiceFunction {
+            r#type: Some(ChatCompletionToolType::Function),
+            function: ChatCompletionToolChoiceFunctionName {
+                name: "get_current_weather".to_string(),
+            },
+        });
+
+        let serialized = serde_json::to_string(&tool_choice).unwrap();
+        assert_eq!(serialized, "{\"type\":\"function\",\"function\":{\"name\":\"get_current_weather\"}}");
+
+        let deserialized: ChatCompletionToolChoice = serde_json::from_str(serialized.as_str()).unwrap();
+        assert_eq!(deserialized, tool_choice)
     }
 }


### PR DESCRIPTION
This PR fixes an issue with the `ChatCompletionToolChoice` enum ; currently the `None`, `Required` and `Auto` values of the enum are not correctly serialized (`null` instead of `"none"`, `"required"` and `"auto"`), which cause issues to call openai compatible APIs.

I added some unit tests: the first test on the "required" value doesn't pass on the master branch, and pass correctly with this fix.