### PR TITLE
Add an extra_body parameter

### DIFF
--- a/openai_dive/src/v1/resources/chat.rs
+++ b/openai_dive/src/v1/resources/chat.rs
@@ -1,11 +1,11 @@
+use super::shared::{ReasoningEffort, WebSearchContextSize};
 use crate::v1::resources::shared::StopToken;
 use crate::v1::resources::shared::{FinishReason, Usage};
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use std::collections::HashMap;
 use std::fmt::Display;
-use serde_json::Value;
-use super::shared::{ReasoningEffort, WebSearchContextSize};
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct ChatCompletionResponse {

--- a/openai_dive/src/v1/resources/chat.rs
+++ b/openai_dive/src/v1/resources/chat.rs
@@ -4,7 +4,7 @@ use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt::Display;
-
+use serde_json::Value;
 use super::shared::{ReasoningEffort, WebSearchContextSize};
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -157,6 +157,10 @@ pub struct ChatCompletionParameters {
     /// This tool searches the web for relevant results to use in a response.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub web_search_options: Option<WebSearchOptions>,
+    /// Allows to pass arbitrary json as an extra_body parameter, for specific features/openai-compatible endpoints.
+    #[serde(flatten)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extra_body: Option<Value>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]


### PR DESCRIPTION
This PR adds a new optional parameter `extra_body` on the `ChatCompletionParameters` struct, which can take an arbitrary JSON. 

This can be used to enable specific features of some OpenAI compatible endpoints, that are not supported by OpenAI.

Example use:

```
let mut builder = &mut ChatCompletionParametersBuilder::default();

let extra = serde_json::json!({
    "repetition_penalty": 1.05,
});

builder = builder.extra_body(extra)
```

This closes issue #121 