### PR TITLE
Adding utility functions to ChatMessage

### DIFF
--- a/openai_dive/src/v1/resources/chat.rs
+++ b/openai_dive/src/v1/resources/chat.rs
@@ -282,7 +282,7 @@ pub enum ChatMessage {
 
 impl ChatMessage {
     /// Get the ChatMessageContent data, if it exists.
-    pub fn message_content(&self) -> Option<&ChatMessageContent> {
+    pub fn message(&self) -> Option<&ChatMessageContent> {
         match self {
             ChatMessage::Developer { content, .. }
             | ChatMessage::System { content, .. }
@@ -297,7 +297,7 @@ impl ChatMessage {
     }
 
     /// Get the content of the message as text, if it is a simple text message.
-    pub fn content_text(&self) -> Option<&str> {
+    pub fn text(&self) -> Option<&str> {
         match self {
             ChatMessage::Developer { content, .. }
             | ChatMessage::System { content, .. }

--- a/openai_dive/src/v1/resources/chat.rs
+++ b/openai_dive/src/v1/resources/chat.rs
@@ -280,7 +280,6 @@ pub enum ChatMessage {
     },
 }
 
-
 impl ChatMessage {
     /// Get the ChatMessageContent data, if it exists.
     pub fn message_content(&self) -> Option<&ChatMessageContent> {
@@ -288,9 +287,12 @@ impl ChatMessage {
             ChatMessage::Developer { content, .. }
             | ChatMessage::System { content, .. }
             | ChatMessage::User { content, .. }
-            | ChatMessage::Assistant { content: Some(content), .. } => { Some(content) }
+            | ChatMessage::Assistant {
+                content: Some(content),
+                ..
+            } => Some(content),
             ChatMessage::Assistant { content: None, .. } => None,
-            ChatMessage::Tool { .. } =>  None,
+            ChatMessage::Tool { .. } => None,
         }
     }
 
@@ -300,7 +302,10 @@ impl ChatMessage {
             ChatMessage::Developer { content, .. }
             | ChatMessage::System { content, .. }
             | ChatMessage::User { content, .. }
-            | ChatMessage::Assistant { content: Some(content), .. } => {
+            | ChatMessage::Assistant {
+                content: Some(content),
+                ..
+            } => {
                 if let ChatMessageContent::Text(text) = content {
                     Some(text)
                 } else {
@@ -387,7 +392,6 @@ pub enum DeltaChatMessage {
         tool_call_id: Option<String>,
     },
 }
-
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct ToolCall {

--- a/openai_dive/src/v1/resources/chat.rs
+++ b/openai_dive/src/v1/resources/chat.rs
@@ -280,6 +280,50 @@ pub enum ChatMessage {
     },
 }
 
+
+impl ChatMessage {
+    /// Get the ChatMessageContent data, if it exists.
+    pub fn message_content(&self) -> Option<&ChatMessageContent> {
+        match self {
+            ChatMessage::Developer { content, .. }
+            | ChatMessage::System { content, .. }
+            | ChatMessage::User { content, .. }
+            | ChatMessage::Assistant { content: Some(content), .. } => { Some(content) }
+            ChatMessage::Assistant { content: None, .. } => None,
+            ChatMessage::Tool { .. } =>  None,
+        }
+    }
+
+    /// Get the content of the message as text, if it is a simple text message.
+    pub fn content_text(&self) -> Option<&str> {
+        match self {
+            ChatMessage::Developer { content, .. }
+            | ChatMessage::System { content, .. }
+            | ChatMessage::User { content, .. }
+            | ChatMessage::Assistant { content: Some(content), .. } => {
+                if let ChatMessageContent::Text(text) = content {
+                    Some(text)
+                } else {
+                    None
+                }
+            }
+            ChatMessage::Assistant { content: None, .. } => None,
+            ChatMessage::Tool { content, .. } => Some(content),
+        }
+    }
+
+    /// Get the name of the message sender, if it exists.
+    pub fn name(&self) -> Option<&str> {
+        match self {
+            ChatMessage::Developer { name, .. }
+            | ChatMessage::System { name, .. }
+            | ChatMessage::User { name, .. }
+            | ChatMessage::Assistant { name, .. } => name.as_deref(),
+            ChatMessage::Tool { .. } => None,
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(tag = "role", rename_all = "lowercase")]
 pub enum DeltaChatMessage {
@@ -343,6 +387,7 @@ pub enum DeltaChatMessage {
         tool_call_id: Option<String>,
     },
 }
+
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct ToolCall {


### PR DESCRIPTION
This PR adds a few utility functions to ChatMessage, to make simple use cases more straightforward with less ceremony. 

I really like the strong typing in this updated version of the crate, but it makes working with the returned structure a bit more ceremonious and complex, dealing with all different possible shapes of the data. 

This adds a utility function to make the simple straightfoward use-cases more straightforward to use. 