### PR TITLE
Added continuous_usage_stats param in /v1/chat/completions

### DIFF
--- a/openai_dive/src/v1/resources/chat.rs
+++ b/openai_dive/src/v1/resources/chat.rs
@@ -171,6 +171,8 @@ pub struct ChatCompletionParameters {
 pub struct ChatCompletionStreamOptions {
     /// If set, an additional chunk will be streamed before the data: [DONE] message.
     pub include_usage: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub continuous_usage_stats: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]


### PR DESCRIPTION
Hello,

this PR adds custom vLLM parameter continuous_usage_stats in billing to avoid accountability problem of customers aborting streaming requests before the end.
See [vllm issue](https://github.com/vllm-project/vllm/issues/5708) for more details about implementation

Thanks !
Quentin