### PR TITLE
Add missing audio voices (ballad, verse, marin and cedar)

### DIFF
--- a/openai_dive/src/v1/resources/audio.rs
+++ b/openai_dive/src/v1/resources/audio.rs
@@ -145,6 +145,7 @@ pub enum AudioVoice {
     #[default]
     Alloy,
     Ash,
+    Ballad,
     Coral,
     Echo,
     Fable,
@@ -152,6 +153,9 @@ pub enum AudioVoice {
     Nova,
     Sage,
     Shimmer,
+    Verse,
+    Marin,
+    Cedar,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]


### PR DESCRIPTION
As specified in [OpenAI documentation](https://platform.openai.com/docs/guides/text-to-speech#supported-languages), theses voices are available for some models: `ballad`, `verse`, `marin` and `cedar`. Currently they are not accessible via `openai-client`. The PR adds the necessary entries in the `AudioVoice` enum.