### PR TITLE
fix: add service_tier to ResponseParameters

### DIFF
--- a/openai_dive/src/v1/resources/response/request.rs
+++ b/openai_dive/src/v1/resources/response/request.rs
@@ -79,6 +79,9 @@ pub struct ResponseParameters {
     /// A unique identifier representing your end-user.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<String>,
+    /// The service tier used for processing the request.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub service_tier: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]


### PR DESCRIPTION
Hello,

This PR adds the `service_tier` parameter to the `ResponseParameters` struct (https://platform.openai.com/docs/api-reference/responses/create#responses_create-service_tier)

Thanks!