### PR TITLE
Add support for an optional reasoning field in Chat Completion output

### DIFF
--- a/openai_dive/src/v1/endpoints/chat.rs
+++ b/openai_dive/src/v1/endpoints/chat.rs
@@ -137,6 +137,7 @@ where
 
                     if let DeltaChatMessage::Untagged {
                         content,
+                        reasoning,
                         reasoning_content,
                         refusal,
                         name: _,
@@ -161,6 +162,7 @@ where
                                 choice.delta = DeltaChatMessage::Assistant {
                                     name: Some("assistant".to_string()),
                                     content: content.clone(),
+                                    reasoning: reasoning.clone(),
                                     reasoning_content: reasoning_content.clone(),
                                     refusal: refusal.clone(),
                                     tool_calls: tool_calls.clone(),

--- a/openai_dive/src/v1/resources/chat.rs
+++ b/openai_dive/src/v1/resources/chat.rs
@@ -266,6 +266,9 @@ pub enum ChatMessage {
         /// The contents of the assistant message. Required unless tool_calls is specified.
         #[serde(skip_serializing_if = "Option::is_none")]
         content: Option<ChatMessageContent>,
+        /// The reasoning content by the assistant.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        reasoning: Option<String>,
         /// The reasoning content by the assistant. (DeepSeek API only)
         #[serde(skip_serializing_if = "Option::is_none")]
         reasoning_content: Option<String>,
@@ -367,6 +370,9 @@ pub enum DeltaChatMessage {
         /// The contents of the assistant message. Required unless tool_calls is specified.
         #[serde(skip_serializing_if = "Option::is_none")]
         content: Option<ChatMessageContent>,
+        /// The reasoning content by the assistant.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        reasoning: Option<String>,
         /// The reasoning content by the assistant. (DeepSeek API only)
         #[serde(skip_serializing_if = "Option::is_none")]
         reasoning_content: Option<String>,
@@ -390,6 +396,8 @@ pub enum DeltaChatMessage {
     Untagged {
         #[serde(skip_serializing_if = "Option::is_none")]
         content: Option<ChatMessageContent>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        reasoning: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         reasoning_content: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
Some inference providers, backends and routers output the reasoning part of the model's response in a `reasoning` field. Currently dive expects the reasoning to be in a `reasoning_content` field (DeepSeek API convention), so for APIs that use `reasoning`, the reasoning is lost.

When GPT-OSS was released, [OpenAI provided guidance](https://developers.openai.com/cookbook/articles/gpt-oss/handle-raw-cot#chat-completions-api) that chain of thought content should be returned in the `reasoning` field of the response, following the OpenRouter convention. They recommend this for Chat Completions API even though it does not officially support returning chain of thought in the official API. Since dive implements the OpenAI API, it makes sense to conform to their recommendations.

As a first step, I suggest to support both fields for now (`reasoning` and `reasoning_content`), to fix the client with the APIs that return `reasoning` without breaking compatibility with existing implementations. 