### PR TITLE
fix: add ResponseStreamEvent::Keepalive

### DIFF
--- a/openai_dive/src/v1/resources/response/response.rs
+++ b/openai_dive/src/v1/resources/response/response.rs
@@ -618,6 +618,11 @@ pub enum ResponseStreamEvent {
         input: String,
     },
 
+    // Keepalive
+    /// keepalive - A heartbeat was sent (it's undocumented, but it exists)
+    #[serde(rename = "keepalive")]
+    Keepalive { sequence_number: u32 },
+
     // Error event
     /// error - An error occurred
     #[serde(rename = "error")]

--- a/openai_dive/src/v1/resources/response/response.rs
+++ b/openai_dive/src/v1/resources/response/response.rs
@@ -722,6 +722,7 @@ impl ResponseStreamEvent {
                 "response.custom_tool_call_input.delta"
             }
             Self::ResponseCustomToolCallInputDone { .. } => "response.custom_tool_call_input.done",
+            Self::Keepalive { .. } => "keepalive",
             Self::Error { .. } => "error",
         }
     }


### PR DESCRIPTION
It's undocumented, but it actually exists. See the error that I received from the API:

```
unknown variant `keepalive`, expected one of `response.created`, `response.queued`, `response.in_progress`, `response.completed`, `response.failed`, `response.incomplete`, `response.output_item.added`, `response.output_item.done`, `response.content_part.added`, `response.content_part.done`, `response.reasoning_part.added`, `response.reasoning_part.done`, `response.output_text.delta`, `response.output_text.done`, `response.output_text.annotation.added`, `response.refusal.delta`, `response.refusal.done`, `response.function_call_arguments.delta`, `response.function_call_arguments.done`, `response.file_search_call.in_progress`, `response.file_search_call.searching`, `response.file_search_call.completed`, `response.web_search_call.in_progress`, `response.web_search_call.searching`, `response.web_search_call.completed`, `response.reasoning_text.delta`, `response.reasoning_text.done`, `response.reasoning_summary_part.added`, `response.reasoning_summary_part.done`, `response.reasoning_summary_text.delta`, `response.reasoning_summary_text.done`, `response.image_generation_call.in_progress`, `response.image_generation_call.generating`, `response.image_generation_call.partial_image`, `response.image_generation_call.completed`, `response.mcp_call.in_progress`, `response.mcp_call.completed`, `response.mcp_call.failed`, `response.mcp_call_arguments.delta`, `response.mcp_call_arguments.done`, `response.mcp_list_tools.in_progress`, `response.mcp_list_tools.completed`, `response.mcp_list_tools.failed`, `response.code_interpreter_call.in_progress`, `response.code_interpreter_call.interpreting`, `response.code_interpreter_call.completed`, `response.code_interpreter_call_code.delta`, `response.code_interpreter_call_code.done`, `response.custom_tool_call_input.delta`, `response.custom_tool_call_input.done`, `error` at line 1 column 19 {"type":"keepalive","sequence_number":3}
```