### PR TITLE
FIx schema description as optional

### DIFF
--- a/openai_dive/src/v1/resources/response/shared.rs
+++ b/openai_dive/src/v1/resources/response/shared.rs
@@ -179,7 +179,7 @@ pub enum ResponseFormat {
     JsonSchema {
         schema: serde_json::Value,
         name: String,
-        description: String,
+        description: Option<String>,
         strict: Option<bool>,
     },
 }


### PR DESCRIPTION
Hello,

As stated in [this documentation item](https://developers.openai.com/api/reference/resources/responses/methods/create#(resource)%20responses%20%3E%20(model)%20response_text_config%20%3E%20(schema)%20%3E%20(property)%20format%20%2B%20(resource)%20responses%20%3E%20(model)%20response_format_text_json_schema_config%20%3E%20(schema)%20%3E%20(property)%20description), description field should be optional not mandatory

Thanks for the review !